### PR TITLE
Fix function signature used when passing ODEModel to hookstep

### DIFF
--- a/src/Hookstep.jl
+++ b/src/Hookstep.jl
@@ -117,7 +117,7 @@ function hookstepsolve(
     xguess::AbstractVector{T},
     params = SearchParams()
 ) where {T<:Real}
-    return hookstepsolve(model.f, model.Df, xguess, params)
+    return hookstepsolve(x -> model.f(x, params.R), x -> model.Df(x, params.R), xguess, params) 
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,4 +77,30 @@ tz = Symmetry(1, 1, 1, 0//1, 1//2)
         xsoln, success = hookstepsolve(fr, Dfr, xguess)
         @test norm(xsoln - xeqb)/norm(xeqb) < 1e-08
     end
+
+    @time @testset "Hookstep Solve with ODEModel and SearchParams" begin
+        α, γ = 1.0, 2.0                     # Fourier wavenumbers α, γ = 2π/Lx, 2π/Lz
+        J,K,L = 1,1,3                       # Bounds on Fourier modes (J,K) and wall-normal polynomials (L)
+
+        params = SearchParams(; R = 200.0)
+
+        H = [sx * sy * sz, sz * tx * tz]    # Generators of the symmetric subspace of the Nagata eqb
+
+        ijkl = basisIndices(J, K, L, H)     # Compute index set of H-symmetric basis elements Ψijkl
+        Ψ = basisSet(α, γ, ijkl)            # Compute basis elements Ψijkl in the index set
+        model = ODEModel(Ψ)                 # Do Galerkin projection, return f(x,R) for ODE dx/dt = f(x,R)
+        Nmodes = length(Ψ)
+
+        # Projection of Nagata eqb used as initial guess for ODE eqb. Computed for PRL
+        xguess = [0.105, -0.0539, 0.388, -0.0172, -0.0133, 0.0113, -0.00706, 0.0240, -0.0344, -0.00868,
+                  -0.01264, -0.0234, -0.0320, -0.0180, -0.00464, 0.0106, 0.0235]
+        xeqb = [0.16764501289529937, -0.018552429231415948, 0.48640800040772025, -0.09759477649001111,
+                -0.03411986464200022, -0.010665050862032609, -0.01731713276665348, 0.020113317487885345,
+                -0.03572908824700301, -0.008809478655993888, -0.018431734698126298, -0.04736482532692928,
+                -0.04609045287990289, -0.03157916691896989, 0.0010374375712356061, 0.01601957685174594,
+                 0.07702704667134751]
+
+        xsoln, success = hookstepsolve(model, xguess, params)
+        @test norm(xsoln - xeqb)/norm(xeqb) < 1e-08
+    end
 end


### PR DESCRIPTION
I didn't properly account for the change (or lack thereof) in the signature of `f` and `Df` before #6 got merged, which broke the new `hookstepsolve` method that took an `ODEModel` as argument

I don't think anyone is using the new `struct`s yet anyways (indeed they probably require some more tweaking to be useful), but might as well fix it up.

I also added a test that uses that new method, which is basically the same as the existing `hookstepsolve` test -- again, might as well be careful 😄 